### PR TITLE
Add hybrid MacOS/ColorOS web demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-Fusionne le meilleur de MacOS et ColorOS dans une UI web interactive. Dock style MacOS, Centre de Contrôle à la ColorOS, fenêtres arrondies effet glass, animations fluides et thème responsive. Idéal pour fans d’UI modernes et expérimentations créatives !
+Fusionne le meilleur de MacOS et ColorOS dans une UI web interactive.
+
+## Lancer l'exemple
+Ouvrez simplement `index.html` dans votre navigateur. Le dock en bas permet
+d'ouvrir l'appli Musique ou d'accéder au centre de contrôle.
+Le bouton "Thème" bascule entre clair et sombre.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,26 @@
+const appContainer=document.getElementById('app-container');
+const controlCenter=document.getElementById('control-center');
+const controlToggle=document.getElementById('control-toggle');
+const themeToggle=document.getElementById('theme-toggle');
+let dark=false;
+
+controlToggle.addEventListener('click',()=>{
+  controlCenter.classList.toggle('hidden');
+});
+
+document.querySelectorAll('.app-icon[data-app]').forEach(btn=>{
+  btn.addEventListener('click',()=>openApp(btn.dataset.app));
+});
+
+function openApp(name){
+  const tpl=document.getElementById(`${name}-app`);
+  if(!tpl)return;
+  const clone=tpl.content.firstElementChild.cloneNode(true);
+  clone.querySelector('.close').onclick=()=>clone.remove();
+  appContainer.appendChild(clone);
+}
+
+themeToggle.addEventListener('click',()=>{
+  dark=!dark;
+  document.body.classList.toggle('dark',dark);
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hybrid OS UI</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div id="wallpaper"></div>
+    <div id="app-container"></div>
+
+    <div id="control-center" class="hidden">
+        <button id="theme-toggle">Thème</button>
+    </div>
+
+    <div id="dock">
+        <button class="app-icon" data-app="music">🎵</button>
+        <button class="app-icon" data-app="photos">📷</button>
+        <button class="app-icon" id="control-toggle">⚙️</button>
+    </div>
+
+    <template id="music-app">
+        <div class="app-window">
+            <header>
+                <h1>Musique</h1>
+                <button class="close">×</button>
+            </header>
+            <div class="content">
+                <p>Lecture en cours…</p>
+            </div>
+        </div>
+    </template>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,52 @@
+/* Global styles with light/dark variables */
+:root{
+  --bg-light: linear-gradient(135deg,#f6d365,#fda085);
+  --bg-dark: linear-gradient(135deg,#0f2027,#203a43,#2c5364);
+  --glass-bg: rgba(255,255,255,0.3);
+  --glass-dark: rgba(0,0,0,0.4);
+  --text-light:#222;
+  --text-dark:#f5f5f5;
+}
+body{
+  margin:0; font-family:sans-serif; color:var(--text-light);
+}
+body.dark{
+  color:var(--text-dark);
+}
+#wallpaper{
+  position:fixed; inset:0; background:var(--bg-light); z-index:-1;
+}
+body.dark #wallpaper{background:var(--bg-dark);} 
+#dock{
+  position:fixed; bottom:1rem; left:50%; transform:translateX(-50%);
+  display:flex; gap:1rem; padding:0.5rem 1rem;
+  background:var(--glass-bg); backdrop-filter:blur(10px); border-radius:20px;
+}
+body.dark #dock{background:var(--glass-dark);} 
+.app-icon{
+  width:3rem; height:3rem; border:none; border-radius:50%;
+  font-size:1.5rem; display:flex; align-items:center; justify-content:center;
+  background:rgba(255,255,255,0.6); backdrop-filter:blur(5px); cursor:pointer;
+}
+body.dark .app-icon{background:rgba(0,0,0,0.6);} 
+#control-center{
+  position:fixed; top:1rem; right:1rem; background:var(--glass-bg);
+  backdrop-filter:blur(12px); padding:1rem; border-radius:20px; box-shadow:0 8px 16px rgba(0,0,0,0.2);
+}
+body.dark #control-center{background:var(--glass-dark);} 
+.hidden{display:none;}
+.app-window{
+  position:absolute; top:20%; left:50%; transform:translateX(-50%);
+  width:80%; max-width:400px; background:var(--glass-bg); backdrop-filter:blur(15px);
+  border-radius:25px; box-shadow:0 8px 20px rgba(0,0,0,0.2); overflow:hidden;
+  animation:float-in 0.4s ease;
+}
+body.dark .app-window{background:var(--glass-dark);} 
+.app-window header{
+  display:flex; justify-content:space-between; padding:0.5rem 1rem; align-items:center;
+}
+.close{background:none; border:none; font-size:1.2rem; cursor:pointer;}
+@keyframes float-in{from{opacity:0; transform:translate(-50%,20px);} to{opacity:1; transform:translate(-50%,0);}}
+@media(min-width:600px){
+  #dock{bottom:2rem;}
+}


### PR DESCRIPTION
## Summary
- create demo app in `index.html` with dock, control center, and sample music app
- style the UI with glassmorphism and responsive gradient backgrounds
- implement interactions and theme toggle in `app.js`
- update README with usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68409fb202188324aa2ee44a81e9e973