### PR TITLE
Add Oppo Store responsive window

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,24 @@
 // gestion des fenêtres
 const dockButtons=document.querySelectorAll('.dock-item');
 const windows=document.querySelectorAll('.window');
+const oppoWindow=document.getElementById('oppo-window');
+const oppoContent=document.getElementById('oppo-content');
+
+function detectDevice(){
+  const w=window.innerWidth, h=window.innerHeight, ua=navigator.userAgent;
+  if(w<=600||/Mobile|Android|iPhone/i.test(ua)) return 'phone';
+  if(w<=1024||/iPad|Tablet/i.test(ua)||(h>w&&navigator.maxTouchPoints>1)) return 'tablet';
+  return 'computer';
+}
+
+function updateOppoContent(){
+  const type=detectDevice();
+  let emoji,name,os;
+  if(type==='phone'){emoji='📱'; name='Oppo Phone'; os='iOS';}
+  else if(type==='tablet'){emoji='📲'; name='Oppo Tablet'; os='iPadOS';}
+  else{emoji='💻'; name='Oppo Computer'; os='MacOS';}
+  oppoContent.innerHTML=`<div class="device-emoji">${emoji}</div><h1>${name}</h1><p>${os}</p>`;
+}
 dockButtons.forEach(btn=>{
   btn.addEventListener('click',()=>openWindow(document.getElementById(btn.dataset.target)));
 });
@@ -33,7 +51,10 @@ windows.forEach(w=>{
 
 function openWindow(el){
   windows.forEach(w=>w.classList.remove('open'));
-  if(el) el.classList.add('open');
+  if(el){
+    el.classList.add('open');
+    if(el===oppoWindow) updateOppoContent();
+  }
 }
 
 // thème clair/sombre
@@ -216,3 +237,8 @@ function formatTime(s){
 
 loadPlaylist();
 volume.dispatchEvent(new Event('input'));
+
+window.addEventListener('resize',()=>{
+  if(oppoWindow.classList.contains('open')) updateOppoContent();
+});
+updateOppoContent();

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         <button class="dock-item" data-target="photos-window">📷</button>
         <button class="dock-item" data-target="notes-window">📝</button>
         <button class="dock-item" data-target="settings-window">⚙️</button>
+        <button class="dock-item" data-target="oppo-window">🛍️</button>
     </div>
 
     <div class="window" id="music-window">
@@ -62,6 +63,11 @@
     <div class="window" id="settings-window">
         <button class="close">✖</button>
         <button id="theme-toggle">Thème</button>
+    </div>
+
+    <div class="window" id="oppo-window">
+        <button class="close">✖</button>
+        <div id="oppo-content"></div>
     </div>
 
     <script src="app.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -53,6 +53,11 @@ body.dark .window{background:var(--glass-dark);}
 .window.open{opacity:1; pointer-events:auto; transform:translate(-50%,-50%) scale(1);}
 .window .close{position:absolute; top:.5rem; right:.5rem; border:none; background:none; color:inherit; font-size:1.2rem; cursor:pointer;}
 
+#oppo-content{text-align:center;}
+#oppo-content .device-emoji{font-size:4rem; margin-bottom:.5rem;}
+#oppo-content h1{margin:.3rem 0;}
+#oppo-content p{margin:0; font-weight:bold;}
+
 .gallery{display:flex; flex-wrap:wrap; gap:.5rem;}
 .gallery img{width:calc(33% - .5rem); border-radius:10px; object-fit:cover;}
 @media(max-width:500px){.gallery img{width:100%;}}


### PR DESCRIPTION
## Summary
- add a new dock entry for **Oppo Store** and its floating window
- style Oppo Store contents
- detect device type and show appropriate Oppo device mockup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b6644eac832483bceb404e42b3a3