### PR TITLE
Add Oppo Store carousel

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,40 +3,27 @@ const dockButtons=document.querySelectorAll('.dock-item');
 const windows=document.querySelectorAll('.window');
 const oppoWindow=document.getElementById('oppo-window');
 const oppoContent=document.getElementById('oppo-content');
-
-// infos produit selon la taille d'\u00e9cran
-const oppoProducts={
-  phone:{
-    img:'Oppo png/oppo find x8 pro.png',
-    title:'Oppo Find X8 Pro \u2013 iOS',
-    desc:'Un smartphone haut de gamme.'
-  },
-  tablet:{
-    img:'Oppo png/Oppo pad.png',
-    title:'Oppo Pad 4 Pro \u2013 iPadOS',
-    desc:'La tablette parfaite pour le divertissement.'
-  },
-  computer:{
-    img:'Oppo png/OppoBook Pro M2.png',
-    title:'OppoBook Pro M2 \u2013 MacOS',
-    desc:'Un notebook puissant pour cr\u00e9er.'
-  }
-};
-
-function detectDevice(){
-  const w=window.innerWidth;
-  if(w<700) return 'phone';
-  if(w<1100) return 'tablet';
-  return 'computer';
-}
-
-function updateOppoContent(){
-  const type=detectDevice();
-  const {img,title,desc}=oppoProducts[type];
-  oppoContent.innerHTML=`<img src="${img}" alt="${title}" class="oppo-img"><h1>${title}</h1><button class="discover-btn">D\u00e9couvrir</button><p class="description">${desc}</p>`;
-  const p=oppoContent.querySelector('.description');
-  // affiche/masque la description
-  oppoContent.querySelector('.discover-btn').onclick=()=>p.classList.toggle('show');
+let slide=0;
+let carouselInit=false;
+function initCarousel(){
+  if(carouselInit) return;
+  carouselInit=true;
+  const track=oppoContent.querySelector('.carousel-track');
+  const slides=[...track.children];
+  const prev=oppoContent.querySelector('.carousel-btn.prev');
+  const next=oppoContent.querySelector('.carousel-btn.next');
+  const update=()=>track.style.transform=`translateX(-${slide*100}%)`;
+  prev.onclick=()=>{slide=(slide-1+slides.length)%slides.length;update();};
+  next.onclick=()=>{slide=(slide+1)%slides.length;update();};
+  let start=null;
+  track.addEventListener('touchstart',e=>start=e.touches[0].clientX);
+  track.addEventListener('touchend',e=>{
+    if(start===null) return;
+    const diff=e.changedTouches[0].clientX-start;
+    if(Math.abs(diff)>50){diff<0?next.onclick():prev.onclick();}
+    start=null;
+  });
+  update();
 }
 dockButtons.forEach(btn=>{
   btn.addEventListener('click',()=>openWindow(document.getElementById(btn.dataset.target)));
@@ -70,9 +57,9 @@ windows.forEach(w=>{
 
 function openWindow(el){
   windows.forEach(w=>w.classList.remove('open'));
-  if(el){
+    if(el){
     el.classList.add('open');
-    if(el===oppoWindow) updateOppoContent();
+    if(el===oppoWindow) initCarousel();
   }
 }
 
@@ -258,6 +245,6 @@ loadPlaylist();
 volume.dispatchEvent(new Event('input'));
 
 window.addEventListener('resize',()=>{
-  if(oppoWindow.classList.contains('open')) updateOppoContent();
+  if(oppoWindow.classList.contains('open')) initCarousel();
 });
-updateOppoContent();
+initCarousel();

--- a/index.html
+++ b/index.html
@@ -67,7 +67,32 @@
 
     <div class="window" id="oppo-window">
         <button class="close">✖</button>
-        <div id="oppo-content"></div>
+        <div id="oppo-content">
+            <div id="oppo-carousel" class="carousel">
+                <div class="carousel-track">
+                    <div class="slide">
+                        <img src="Oppo png/oppo find x8 pro.png" alt="Oppo Find X8 Pro – iOS">
+                        <h2>Oppo Find X8 Pro – iOS</h2>
+                        <p class="subtitle">StarYAM OS Edition</p>
+                        <button class="discover-btn">Découvrir</button>
+                    </div>
+                    <div class="slide">
+                        <img src="Oppo png/Oppo pad.png" alt="Oppo Pad 4 Pro – iPadOS">
+                        <h2>Oppo Pad 4 Pro – iPadOS</h2>
+                        <p class="subtitle">StarYAM OS Edition</p>
+                        <button class="discover-btn">Découvrir</button>
+                    </div>
+                    <div class="slide">
+                        <img src="Oppo png/OppoBook Pro M2.png" alt="OppoBook Pro M2 – MacOS">
+                        <h2>OppoBook Pro M2 – MacOS</h2>
+                        <p class="subtitle">StarYAM OS Edition</p>
+                        <button class="discover-btn">Découvrir</button>
+                    </div>
+                </div>
+                <button class="carousel-btn prev">◀</button>
+                <button class="carousel-btn next">▶</button>
+            </div>
+        </div>
     </div>
 
     <script src="app.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -53,14 +53,20 @@ body.dark .window{background:var(--glass-dark);}
 .window.open{opacity:1; pointer-events:auto; transform:translate(-50%,-50%) scale(1);}
 .window .close{position:absolute; top:.5rem; right:.5rem; border:none; background:none; color:inherit; font-size:1.2rem; cursor:pointer;}
 
-#oppo-content{display:flex;flex-direction:column;align-items:center;text-align:center;}
-/* visuel du produit */
-.oppo-img{width:80%;max-width:220px;height:auto;border-radius:20px;margin-bottom:.5rem;box-shadow:0 4px 12px rgba(0,0,0,0.3);}
-#oppo-content h1{margin:.5rem 0;}
+#oppo-content{display:flex;flex-direction:column;align-items:center;}
+.carousel{position:relative;width:100%;overflow:hidden;}
+.carousel-track{display:flex;transition:transform .4s ease;}
+.slide{flex:0 0 100%;padding:1rem;box-sizing:border-box;display:flex;flex-direction:column;align-items:center;text-align:center;}
+.slide img{width:80%;max-width:220px;border-radius:20px;margin-bottom:.5rem;box-shadow:0 4px 12px rgba(0,0,0,0.3);}
+.slide h2{margin:.5rem 0 0;}
+.subtitle{font-size:.9rem;opacity:.8;}
+.carousel-btn{position:absolute;top:50%;transform:translateY(-50%);border:none;border-radius:50%;padding:.3rem .6rem;cursor:pointer;background:var(--glass-light);color:inherit;}
+body.dark .carousel-btn{background:var(--glass-dark);}
+.carousel-btn.prev{left:.5rem;}
+.carousel-btn.next{right:.5rem;}
+.carousel-btn:hover{background:var(--accent);color:#fff;}
 .discover-btn{margin-top:.5rem;padding:.4rem 1rem;border:none;border-radius:20px;font-weight:bold;background:var(--accent);color:#fff;cursor:pointer;transition:transform .2s,box-shadow .2s;}
 .discover-btn:hover{transform:scale(1.05);box-shadow:0 4px 12px rgba(0,0,0,0.3);}
-.description{display:none;margin-top:.5rem;font-size:.9rem;}
-.description.show{display:block;}
 
 .gallery{display:flex; flex-wrap:wrap; gap:.5rem;}
 .gallery img{width:calc(33% - .5rem); border-radius:10px; object-fit:cover;}


### PR DESCRIPTION
## Summary
- integrate a horizontal carousel in the Oppo Store window
- style carousel elements for light/dark modes
- implement minimal JS slider with swipe support

## Testing
- `node --check app.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684139da7b948324b7f40630b01dba6b