### PR TITLE
Add mock system alert

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@
 // boutons du dock (hors troll)
 const dockButtons=document.querySelectorAll('.dock-item[data-target]');
 const trollBtn=document.getElementById('troll-button');
+const alertBtn=document.getElementById('alert-btn');
 const trollInSettings=document.getElementById('troll-btn');
 // lecture de sons
 function playSound(name){
@@ -52,6 +53,7 @@ dockButtons.forEach(btn=>{
   btn.addEventListener('click',()=>openWindow(document.getElementById(btn.dataset.target)));
 });
 trollBtn&&trollBtn.addEventListener('click',()=>playSound('yehaw'));
+alertBtn&&alertBtn.addEventListener('click',launchAlert);
 document.querySelectorAll('.window .close').forEach(c=>c.onclick=()=>c.parentElement.classList.remove('open'));
 
 // slide down to close for touch devices
@@ -119,6 +121,10 @@ const callPhoto=document.getElementById('call-photo');
 const callTitle=document.getElementById('call-title');
 const answerBtn=document.getElementById('call-answer');
 const declineBtn=document.getElementById('call-decline');
+const alertOverlay=document.getElementById('alert-overlay');
+const alertBox=alertOverlay.querySelector('.alert-box');
+const alertOk=document.getElementById('alert-ok');
+const alertIgnore=document.getElementById('alert-ignore');
 const contacts={
   Rodrigue:{sound:'cat-iphone-ringtone',img:'img/contacts/rodrigue.svg'},
   Nouhaila:{sound:'notif',img:'img/contacts/nouhaila.svg'},
@@ -155,6 +161,22 @@ function openPhoneApp(){
 
 answerBtn.addEventListener('click',closeCall);
 declineBtn.addEventListener('click',closeCall);
+
+let alertTimer;
+function launchAlert(){
+  playSound('error');
+  if(navigator.vibrate) navigator.vibrate(200);
+  alertOverlay.classList.add('show');
+  alertBox.classList.add('shake');
+  clearTimeout(alertTimer);
+  alertTimer=setTimeout(closeAlert,10000);
+  setTimeout(()=>alertBox.classList.remove('shake'),500);
+}
+
+function closeAlert(){
+  alertOverlay.classList.remove('show');
+  clearTimeout(alertTimer);
+}
 
 function showAlert(msg){
   playSound('warning');

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <button class="dock-item" data-target="settings-window">⚙️</button>
         <button class="dock-item" onclick="openPhoneApp()" title="Téléphone"><img src="img/phone.svg" alt="Téléphone"></button>
         <button id="troll-button" class="dock-item" title="Troll">🤠</button>
+        <button id="alert-btn" class="dock-item" title="Alerte">❌</button>
         <button class="dock-item" data-target="oppo-window" title="Oppo Store">🛍️</button>
     </div>
 
@@ -135,6 +136,18 @@
             <div class="actions">
                 <button id="call-answer" class="answer">Répondre</button>
                 <button id="call-decline" class="decline">Refuser</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="alert-overlay" class="alert-overlay">
+        <div class="alert-box">
+            <span class="alert-icon">❌</span>
+            <p class="alert-title">Ne pas voter pour Bardella</p>
+            <p class="alert-sub">Ce choix est dangereux pour l'égalité et les libertés.</p>
+            <div class="alert-actions">
+                <button id="alert-ok" class="ok">✅ Compris</button>
+                <button id="alert-ignore" class="ignore">🗑️ Ignorer</button>
             </div>
         </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -139,6 +139,20 @@ body.dark .call-card{background:var(--glass-dark);}
 .actions .decline{background:#e53935;}
 .call-photo{width:80px;height:80px;border-radius:50%;margin-bottom:.5rem;object-fit:cover;box-shadow:0 2px 6px rgba(0,0,0,0.3);}
 
+/* Alerte système */
+.alert-overlay{position:fixed;inset:0;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.4);z-index:30;visibility:hidden;opacity:0;transition:opacity .3s;}
+.alert-overlay.show{visibility:visible;opacity:1;}
+.alert-box{background:var(--glass-light);backdrop-filter:blur(20px) saturate(160%);border-radius:20px;padding:1rem;width:90%;max-width:280px;text-align:center;box-shadow:0 8px 20px rgba(0,0,0,0.3);transform:scale(0.9);transition:transform .3s;}
+.alert-overlay.show .alert-box{transform:scale(1);}
+body.dark .alert-box{background:var(--glass-dark);}
+.alert-icon{font-size:2rem;color:#e53935;display:block;margin-bottom:.5rem;}
+.alert-actions{display:flex;gap:.5rem;justify-content:center;margin-top:1rem;}
+.alert-actions button{flex:1;padding:.4rem .8rem;border:none;border-radius:12px;cursor:pointer;color:#fff;}
+.alert-actions .ok{background:var(--accent);}
+.alert-actions .ignore{background:#666;}
+.alert-box.shake{animation:shake .5s;}
+@keyframes shake{0%,100%{transform:translateX(0);}20%{transform:translateX(-3px);}40%{transform:translateX(3px);}60%{transform:translateX(-2px);}80%{transform:translateX(2px);}}
+
 
 /* Phone app */
 #phone-window .contacts{display:flex;flex-direction:column;gap:.8rem;}


### PR DESCRIPTION
## Summary
- add new ❌ button in the dock
- create HTML markup for the alert overlay
- style the alert with glassmorphism and dark mode support
- implement `launchAlert` JS logic for auto-closing animated alert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684172908c148324b457de7d86720841