### PR TITLE
Implement ignore handler for call overlay

### DIFF
--- a/app.js
+++ b/app.js
@@ -121,6 +121,7 @@ const callPhoto=document.getElementById('call-photo');
 const callTitle=document.getElementById('call-title');
 const answerBtn=document.getElementById('call-answer');
 const declineBtn=document.getElementById('call-decline');
+const ignoreBtn=document.getElementById('call-ignore');
 const alertOverlay=document.getElementById('alert-overlay');
 const alertBox=alertOverlay.querySelector('.alert-box');
 const alertOk=document.getElementById('alert-ok');
@@ -161,6 +162,10 @@ function openPhoneApp(){
 
 answerBtn.addEventListener('click',closeCall);
 declineBtn.addEventListener('click',closeCall);
+ignoreBtn&&ignoreBtn.addEventListener('click',()=>{
+  document.querySelector('.call-overlay').classList.remove('active');
+  playSound('error');
+});
 
 let alertTimer;
 function launchAlert(){


### PR DESCRIPTION
## Summary
- add `ignoreBtn` element lookup
- hide `.call-overlay` and play `error.mp3` when ignoring

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841844c6940832496b59f4b87550865