### PR TITLE
Add responsive home widgets

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,23 @@
 </head>
 <body>
     <div id="wallpaper"></div>
+    <div id="home">
+        <div class="page">
+            <div class="widget clock-widget"></div>
+            <div class="widget weather-widget">☀️ 25°C</div>
+            <div class="widget battery-widget">--%</div>
+            <div class="widget calendar-widget"></div>
+            <div class="widget game-widget">
+                <div id="mini-game" class="mini2048"></div>
+            </div>
+        </div>
+        <div class="page"></div>
+    </div>
 
     <div id="dock">
         <button class="dock-item" data-target="music-window">🎵</button>
         <button class="dock-item" data-target="photos-window">📷</button>
-        <button class="dock-item" data-target="notes-window">📝</button>
+        <button class="dock-item" data-target="messages-window">💬</button>
         <button class="dock-item" data-target="settings-window">⚙️</button>
         <button class="dock-item" onclick="openPhoneApp()" title="Téléphone"><img src="img/phone.svg" alt="Téléphone"></button>
         <button id="troll-button" class="dock-item" title="Troll">🤠</button>
@@ -60,9 +72,9 @@
         </div>
     </div>
 
-    <div class="window" id="notes-window">
+    <div class="window" id="messages-window">
         <button class="close">✖</button>
-        <textarea id="note-area" placeholder="Vos notes..."></textarea>
+        <textarea id="message-area" placeholder="Vos messages..."></textarea>
     </div>
 
     <div class="window" id="settings-window">
@@ -168,6 +180,8 @@
             </div>
         </div>
     </div>
+
+    <div id="multitask" class="multitask"></div>
 
     <script src="app.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -16,7 +16,28 @@ body{
 }
 body.dark{background:var(--bg-dark); color:var(--text-dark);}
 
-#wallpaper{position:fixed; inset:0; z-index:-1; background:inherit;}
+#wallpaper{position:fixed; inset:0; z-index:-1; background:inherit; overflow:hidden;}
+#wallpaper::before{
+  content:''; position:absolute; inset:0;
+  background:inherit; filter:blur(40px);
+  background-size:200% 200%; animation:movebg 20s linear infinite;
+}
+@keyframes movebg{0%{background-position:0 0;}50%{background-position:100% 50%;}100%{background-position:0 100%;}}
+
+#home{position:fixed;inset:0;display:flex;overflow:hidden;z-index:1;}
+#home .page{flex:0 0 100%;display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));grid-auto-rows:120px;gap:1rem;padding:1rem;transition:transform .4s;}
+#home .widget{display:flex;align-items:center;justify-content:center;border-radius:20px;background:var(--glass-light);backdrop-filter:blur(20px) saturate(160%);color:inherit;font-size:1rem;}
+body.dark #home .widget{background:var(--glass-dark);}
+.mini2048{position:relative;width:100%;height:100%;background:#111;border-radius:12px;display:grid;grid-template-columns:repeat(4,1fr);grid-auto-rows:1fr;gap:2px;}
+.mini2048 .cell-bg{background:#222;border-radius:4px;}
+.mini2048 .tile{position:absolute;width:calc(25% - 2px);height:calc(25% - 2px);display:flex;align-items:center;justify-content:center;font-size:.8rem;font-weight:bold;color:#fff;border-radius:4px;transition:transform .15s;}
+.mini2048 .tile.appear{animation:mini-pop .2s;}
+@keyframes mini-pop{from{transform:scale(0);}to{transform:scale(1);}}
+
+.multitask{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,0.5);z-index:30;flex-wrap:wrap;padding:1rem;}
+.multitask.show{display:flex;}
+.multitask .card{width:80px;height:80px;margin:.5rem;border-radius:12px;background:var(--glass-light);display:flex;align-items:center;justify-content:center;font-size:.8rem;color:inherit;}
+body.dark .multitask .card{background:var(--glass-dark);}
 
 #dock{
   position:fixed; bottom:1rem; left:50%; transform:translateX(-50%);
@@ -41,6 +62,8 @@ body.dark .dock-item{background:var(--glass-dark);}
   .dock-item:active{transform:scale(0.95);}
 }
 .dock-item img{width:70%;height:70%;object-fit:cover;border-radius:50%;}
+.dock-item:active{animation:bounce .5s;}
+@keyframes bounce{0%{transform:translateY(0);}30%{transform:translateY(-8px);}60%{transform:translateY(4px);}100%{transform:translateY(0);}}
 
 .window{
   position:fixed; top:50%; left:50%; transform:translate(-50%,-50%) scale(0.8);
@@ -73,11 +96,11 @@ body.dark .carousel-btn{background:var(--glass-dark);}
 .gallery img{width:calc(33% - .5rem); border-radius:10px; object-fit:cover;}
 @media(max-width:500px){.gallery img{width:100%;}}
 
-#note-area{
+#message-area{
   width:100%; height:200px; border:none; border-radius:12px; padding:.5rem;
   background:var(--glass-light); color:inherit;
 }
-body.dark #note-area{background:var(--glass-dark);}
+body.dark #message-area{background:var(--glass-dark);}
 
 .player{
   width:90%; max-width:400px; padding:1rem; border-radius:25px;


### PR DESCRIPTION
## Summary
- add interactive home screen with widgets and mini 2048
- animate wallpaper and dock
- support swipe gestures and multitask overlay
- rename notes to messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684209c97d8c8324ad3cbd120a99bee5